### PR TITLE
Add DS1822 sensor support

### DIFF
--- a/adafruit_ds18x20.py
+++ b/adafruit_ds18x20.py
@@ -45,7 +45,7 @@ class DS18X20(object):
     """Class which provides interface to DS18X20 temperature sensor."""
 
     def __init__(self, bus, address):
-        if address.family_code == 0x10 or address.family_code == 0x28:
+        if address.family_code == 0x10 or address.family_code == 0x28 or address.family_code == 0x22:
             self._address = address
             self._device = OneWireDevice(bus, address)
             self._buf = bytearray(9)

--- a/adafruit_ds18x20.py
+++ b/adafruit_ds18x20.py
@@ -45,7 +45,7 @@ class DS18X20(object):
     """Class which provides interface to DS18X20 temperature sensor."""
 
     def __init__(self, bus, address):
-        if address.family_code == 0x10 or address.family_code == 0x28 or address.family_code == 0x22:
+        if address.family_code in (0x10, 0x28, 0x22):
             self._address = address
             self._device = OneWireDevice(bus, address)
             self._buf = bytearray(9)


### PR DESCRIPTION
DS1822P sensor behaves just like the DS18B20 except for the following:
- it has a different family code: 0x22
- it has only the GND and DQ pins connected, it uses parasite power from the data line

Note for ESP8266 users (definitely true on Wemos D1 board): use 1kOhm pull-up resistor between the data line and the 3.3V