### PR TITLE
Add multi sensor example

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,5 +30,5 @@ repos:
         name: pylint (examples code)
         description: Run pylint rules on "examples/*.py" files
         entry: /usr/bin/env bash -c
-        args: ['([[ ! -d "examples" ]] || for example in $(find . -path "./examples/*.py"); do pylint --disable=missing-docstring,invalid-name $example; done)']
+        args: ['([[ ! -d "examples" ]] || for example in $(find . -path "./examples/*.py"); do pylint --disable=missing-docstring,invalid-name,consider-using-f-string $example; done)']
         language: system

--- a/examples/ds18x20_multi.py
+++ b/examples/ds18x20_multi.py
@@ -2,8 +2,8 @@
 # These ROM codes need to be determined ahead of time. Use `ow_bus.scan()`.
 #
 # (1) Connect one sensor at a time
-# (2) Use `ow_bus.scan()` to determine ROM code
-# (3) Use ROM code to specify sensors
+# (2) Use `ow_bus.scan()[0].rom` to determine ROM code
+# (3) Use ROM code to specify sensors (see this example)
 
 import time
 import board

--- a/examples/ds18x20_multi.py
+++ b/examples/ds18x20_multi.py
@@ -1,0 +1,33 @@
+# Example of specifying multiple sensors using explicit ROM codes.
+# These ROM codes need to be determined ahead of time. Use `ow_bus.scan()`.
+#
+# (1) Connect one sensor at a time
+# (2) Use `ow_bus.scan()` to determine ROM code
+# (3) Use ROM code to specify sensors
+
+import time
+import board
+from adafruit_onewire.bus import OneWireBus, OneWireAddress
+from adafruit_ds18x20 import DS18X20
+
+# !!!! REPLACE THESE WITH ROM CODES FOR YOUR SENSORS !!!!
+ROM1 = b"(\xbb\xfcv\x08\x00\x00\xe2"
+ROM2 = b"(\xb3t\xd3\x08\x00\x00\x9e"
+ROM3 = b"(8`\xd4\x08\x00\x00i"
+# !!!! REPLACE THESE WITH ROM CODES FOR YOUR SENSORS !!!!
+
+# Initialize one-wire bus on board pin D5.
+ow_bus = OneWireBus(board.D5)
+
+# Use pre-determined ROM codes for each sensors
+temp1 = DS18X20(ow_bus, OneWireAddress(ROM1))
+temp2 = DS18X20(ow_bus, OneWireAddress(ROM2))
+temp3 = DS18X20(ow_bus, OneWireAddress(ROM3))
+
+# Main loop to print the temperatures every second.
+while True:
+    print("Temperature 1 = {}".format(temp1.temperature))
+    print("Temperature 2 = {}".format(temp2.temperature))
+    print("Temperature 3 = {}".format(temp3.temperature))
+    print("-" * 20)
+    time.sleep(1)

--- a/examples/ds18x20_multi.py
+++ b/examples/ds18x20_multi.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2020 ladyada for Adafruit Industries
+# SPDX-License-Identifier: MIT
+
 # Example of specifying multiple sensors using explicit ROM codes.
 # These ROM codes need to be determined ahead of time. Use `ow_bus.scan()`.
 #
@@ -18,6 +21,10 @@ ROM3 = b"(8`\xd4\x08\x00\x00i"
 
 # Initialize one-wire bus on board pin D5.
 ow_bus = OneWireBus(board.D5)
+
+# Uncomment this to get a listing of currently attached ROMs
+# for device in ow_bus.scan():
+#     print(device.rom)
 
 # Use pre-determined ROM codes for each sensors
 temp1 = DS18X20(ow_bus, OneWireAddress(ROM1))


### PR DESCRIPTION
Adds an example that's a little more real world than simpletest example. Demonstrates how to setup multiple sensors with known ROM codes, which can be determined using scan.

```python
Adafruit CircuitPython 7.0.0 on 2021-09-20; Adafruit Metro M4 Express with samd51j19
>>> import ds18x20_multi
Temperature 1 = 20.9375
Temperature 2 = 20.8125
Temperature 3 = 21.75
--------------------
Temperature 1 = 21.0
Temperature 2 = 20.875
Temperature 3 = 21.75
--------------------
Temperature 1 = 21.0
Temperature 2 = 20.875
Temperature 3 = 21.75
--------------------
```