### PR TITLE
Fix a few type hints

### DIFF
--- a/adafruit_ds18x20.py
+++ b/adafruit_ds18x20.py
@@ -22,7 +22,7 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_DS18x20.git"
 
 import time
 from micropython import const
-from adafruit_onewire.device import OneWireDevice
+from adafruit_onewire.device import OneWireAddress, OneWireDevice
 
 try:
     import typing  # pylint: disable=unused-import
@@ -36,7 +36,7 @@ _CONVERT = b"\x44"
 _RD_SCRATCH = b"\xBE"
 _WR_SCRATCH = b"\x4E"
 _CONVERSION_TIMEOUT = const(1)
-RESOLUTION = (9, 10, 11, 12)
+RESOLUTION: tuple[Literal[9, 10, 11, 12], ...] = (9, 10, 11, 12)
 # Maximum conversion delay in seconds, from DS18B20 datasheet.
 _CONVERSION_DELAY = {9: 0.09375, 10: 0.1875, 11: 0.375, 12: 0.750}
 
@@ -74,7 +74,7 @@ class DS18X20:
 
     """
 
-    def __init__(self, bus: OneWireBus, address: int) -> None:
+    def __init__(self, bus: OneWireBus, address: OneWireAddress) -> None:
         if address.family_code in (0x10, 0x28):
             self._address = address
             self._device = OneWireDevice(bus, address)
@@ -84,7 +84,7 @@ class DS18X20:
             raise ValueError("Incorrect family code in device address.")
 
     @property
-    def temperature(self):
+    def temperature(self) -> float:
         """The temperature in degrees Celsius."""
         self._convert_temp()
         return self._read_temp()

--- a/adafruit_ds18x20.py
+++ b/adafruit_ds18x20.py
@@ -22,13 +22,14 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_DS18x20.git"
 
 import time
 from micropython import const
-from adafruit_onewire.device import OneWireAddress, OneWireDevice
+from adafruit_onewire.device import OneWireDevice
 
 try:
     import typing  # pylint: disable=unused-import
     from typing_extensions import Literal
     from circuitpython_typing import WriteableBuffer
     from adafruit_onewire.bus import OneWireBus  # pylint: disable=ungrouped-imports
+    from adafruit_onewire.device import OneWireAddress
 except ImportError:
     pass
 


### PR DESCRIPTION
This PR fixes three type hints:
 - The DS18X20 class constructor was accepting an integer address, but it actually needs a `OneWireAddress`.  I imported `OneWireAddress` and updated the type hint.
 - While in there, I also noticed that the `temperature` property was not type hinted, so I added `float`
 - And with a run of `mypy`, I picked up that the `RESOLUTION` tuple could be improved.  As it is now, it is just a tuple of ints, not constrained to 9, 10, 11, 12.  And thus, the `resolution` properties were not being strictly typed.  I added a type hint to `RESOLUTION` so that each entry in the `tuple` is constrained to the values 9, 10, 11, 12, and now it's more strictly typing that property. 

If you need me to add more explanation, change anything, or pull any of the changes back out, I'm happy to do it.  I'm not planning on setting up a full dev environment to run the CI suite locally, so I'll watch to see any results.

Thanks!

Fixes #33 